### PR TITLE
feat(#6): add behavior to the radio box to select winner on each match

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -353,6 +353,11 @@ export function render($chart, totalParties) {
         if (match.size % 2 > 0) {
           $match.classList.add('odd')
         }
+        
+        if (match.singular) {
+          $match.classList.add('singular');
+          enableNextRound(match.next.round, match.next.side); // Imidiately enable the radio box on next match
+        }        
       }
 
       if (round.id === rounds.length) {
@@ -391,8 +396,30 @@ export function render($chart, totalParties) {
           $check.value = party.side
           $check.placeholder = party.name
 
+          if(roundId > 0){
+            $check.disabled = true
+          } 
+
           $name.setAttribute('for', $check.id)
           $participant.append($check)
+
+          $check.addEventListener('change', () => {
+            if ($check.checked) {
+              const inputs = $matchInner.querySelectorAll('input[type="radio"]');
+              inputs.forEach(input => (input.disabled = true));
+            }
+
+            const winnerName = party.name
+            console.log(winnerName) 
+          
+            // check if all match in the round already finish
+            const allDecided = checkAllMatchesInRound(roundId);
+            if (allDecided || match.singular) {
+              const currentRound = document.querySelector(`#round-${roundId}`);
+              currentRound.classList.add('completed');
+              enableNextRound(match.next.round, match.next.side);
+            }
+          })
         }
 
         $matchInner.append($participant)
@@ -406,3 +433,36 @@ export function render($chart, totalParties) {
     $chart.append($section)
   }
 }
+
+/**
+ * @param {number} roundId
+ * @returns {boolean}
+ */
+function checkAllMatchesInRound(roundId) {
+  const roundElement = document.querySelector(`#round-${roundId}`);
+  const inputs = roundElement.querySelectorAll('input[type="radio"]');
+  return Array.from(inputs).every(input => input.disabled);
+}
+
+/**
+ * @param {number} nextRoundId
+ */
+function enableNextRound(nextRoundId) {
+  const nextRound = document.getElementById(`round-${nextRoundId}`);
+  if (!nextRound) {
+    console.log(`round-${nextRoundId} not found`);
+    return;
+  }
+
+  // enable all match on the next round
+  const matches = nextRound.querySelectorAll('.match');
+  matches.forEach(match => {
+    const inputs = match.querySelectorAll('input[type="radio"]');
+    inputs.forEach(input => {
+      input.disabled = false;
+    });
+  });
+}
+
+
+

--- a/lib/main.js
+++ b/lib/main.js
@@ -388,11 +388,11 @@ export function render($chart, parties) {
         if (match.size % 2 > 0) {
           $match.classList.add('odd')
         }
-        
+
         if (match.singular) {
-          $match.classList.add('singular');
-          enableNextRound(match.next.round, match.next.side); // Imidiately enable the radio box on next match
-        }        
+          $match.classList.add('singular')
+          enableNextRound(match.next.round, match.next.side) // Imidiately enable the radio box on next match
+        }
       }
 
       if (round.id === rounds.length) {
@@ -431,28 +431,25 @@ export function render($chart, parties) {
           $check.value = party.side
           $check.placeholder = party.name
 
-          if(roundId > 0){
+          if (roundId > 0) {
             $check.disabled = true
-          } 
+          }
 
           $name.setAttribute('for', $check.id)
           $participant.append($check)
 
           $check.addEventListener('change', () => {
             if ($check.checked) {
-              const inputs = $matchInner.querySelectorAll('input[type="radio"]');
-              inputs.forEach(input => (input.disabled = true));
+              const inputs = $matchInner.querySelectorAll('input[type="radio"]')
+              inputs.forEach(input => (input.disabled = true))
             }
 
-            const winnerName = party.name
-            console.log(winnerName) 
-          
             // check if all match in the round already finish
-            const allDecided = checkAllMatchesInRound(roundId);
+            const allDecided = checkAllMatchesInRound(roundId)
             if (allDecided || match.singular) {
-              const currentRound = document.querySelector(`#round-${roundId}`);
-              currentRound.classList.add('completed');
-              enableNextRound(match.next.round, match.next.side);
+              const currentRound = document.querySelector(`#round-${roundId}`)
+              currentRound.classList.add('completed')
+              enableNextRound(match.next.round, match.next.side)
             }
           })
         }
@@ -474,30 +471,26 @@ export function render($chart, parties) {
  * @returns {boolean}
  */
 function checkAllMatchesInRound(roundId) {
-  const roundElement = document.querySelector(`#round-${roundId}`);
-  const inputs = roundElement.querySelectorAll('input[type="radio"]');
-  return Array.from(inputs).every(input => input.disabled);
+  const roundElement = document.querySelector(`#round-${roundId}`)
+  const inputs = roundElement.querySelectorAll('input[type="radio"]')
+  return Array.from(inputs).every(input => input.disabled)
 }
 
 /**
  * @param {number} nextRoundId
  */
 function enableNextRound(nextRoundId) {
-  const nextRound = document.getElementById(`round-${nextRoundId}`);
+  const nextRound = document.getElementById(`round-${nextRoundId}`)
   if (!nextRound) {
-    console.log(`round-${nextRoundId} not found`);
-    return;
+    return
   }
 
   // enable all match on the next round
-  const matches = nextRound.querySelectorAll('.match');
-  matches.forEach(match => {
-    const inputs = match.querySelectorAll('input[type="radio"]');
-    inputs.forEach(input => {
-      input.disabled = false;
-    });
-  });
+  const matches = nextRound.querySelectorAll('.match')
+  matches.forEach((match) => {
+    const inputs = match.querySelectorAll('input[type="radio"]')
+    inputs.forEach((input) => {
+      input.disabled = false
+    })
+  })
 }
-
-
-


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adding behaviour to the radio box, after the radio box is checked it become disabled and after all match in the first round complete, the radio box in the next round will be enable

### Additional context

I do write function to check all the match in the round from the radio box that already checked to enable the next round, it might be because i missread the issue 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/feryardiant/.github/blob/master/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.