### PR TITLE
fix(#5): fix match position

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -352,6 +352,10 @@ export function render($chart, totalParties) {
       $match.style.setProperty('--span', match.span || 0)
       $match.classList.add('match')
 
+      if (match.size > 1 && match.size % 2 > 0) {
+        $match.classList.add('odd')
+      }
+
       if (roundId > 0) {
         $match.classList.add('has-prev')
 

--- a/lib/style.css
+++ b/lib/style.css
@@ -85,6 +85,7 @@ header #value {
 }
 
 .match {
+  --vheight: 50%;
   --round-id: calc(var(--curr-round) + 1);
   --inner-width: calc(var(--width) + 4px + var(--gap));
   --inner-height: calc(((var(--height) + var(--gap)) * var(--size)) - var(--gap));
@@ -96,6 +97,16 @@ header #value {
   align-items: center;
   isolation: isolate;
   height: var(--inner-height);
+}
+
+.match.odd {
+  --inner-gap: calc((var(--height) + var(--gap)) / 2);
+  margin-top: var(--inner-gap);
+  height: calc(var(--inner-height) - var(--inner-gap));
+}
+
+.match.odd[data-side=red]:after {
+  --vheight: 60%;
 }
 
 .match-inner {
@@ -127,7 +138,7 @@ header #value {
   --target: calc(var(--next-round) - var(--curr-round));
   --outer-width: calc(var(--inner-width) + ((var(--gap) - 6.3px) * var(--target)));
   --hline: calc(var(--outer-width) * var(--target) - (var(--outer-width) / 2));
-  --vline: calc(50% + (var(--gap) * var(--target)));
+  --vline: calc(var(--vheight) + (var(--gap) * var(--target)));
   width: var(--hline);
   height: var(--vline);
   right: calc(var(--hline) * -1);


### PR DESCRIPTION
Fix match position as described in #5 by adding `odd` class on any matches with odd number of `size`, for instance in 19 participants this changes will impacts match 16, 17, 18, 20 & 21

![Screenshot 2024-11-24 at 21 40 03](https://github.com/user-attachments/assets/3143a56e-62b6-4795-ab04-71551132647f)

Even though the positioning of match 20 & 21 remain less-perfect, it should be good enough for now.

close #5