### PR TITLE
feat: use better terms that commonly used in a tournament

### DIFF
--- a/lib/matches.js
+++ b/lib/matches.js
@@ -80,12 +80,11 @@ export class Match {
    * Determine target match based on existing entry.
    *
    * @param {Match[]} matches All registered matches in this round
-   * @param {number} index Index of current entry
+   * @param {number} index Index of current matchup entry
    * @param {number} total Total number of current split
    * @param {(num: number, match: Match) => number} fnId
    */
   initialize(matches, index, total, fnId) {
-    const prevOne = matches.at(-1)
     const lastMatch = total > 1 && (index + 1) === total
 
     this.next = new MatchNext(this.round + 1, index + 1)
@@ -103,7 +102,7 @@ export class Match {
 
     // Force next side to be `red` when it was the last match in the split or
     // the previous registered match was a singularn
-    if (lastMatch || prevOne?.singular) {
+    if (lastMatch || matches.at(-1)?.singular) {
       this.next.side = 'red'
     }
   }
@@ -169,33 +168,96 @@ export class MatchNext {
 }
 
 /**
+ * Refers to the pairing of two contestants to compete against each other.
+ */
+export class Matchup {
+  /** @type {number} */
+  index = 0
+
+  /** @type {boolean} Determine whether this matchup only contains single participant */
+  get singular() {
+    return this.red === undefined
+  }
+
+  /**
+   * @param {number} index
+   * @param {Party} blue
+   * @param {Party|undefined} red
+   */
+  constructor(index, blue, red = undefined) {
+    this.index = index
+    this.blue = blue
+    this.red = red
+  }
+}
+
+/**
+ * Process of arranging two contestants to face each other in a match.
+ *
+ * @param {Party[]} parties List of available participants
+ * @returns {Matchup[]}
+ */
+export function matchmakingParties(parties) {
+  // Ensure current parties has correct ordering based on their
+  // prior total match compared to their index on that match
+  parties.sort((a, b) => a.order - b.order)
+
+  // Track index of `parties` that has been added to `returns`
+  const ns = []
+
+  return parties.reduce((returns, party, p, parties) => {
+    const r = p + 1
+
+    // Skip if current `p` is already added to `ns`
+    // or current `party` was a red one
+    if (ns.includes(p) || party.side === 'red' || !parties[r]) {
+      return returns
+    }
+
+    ns.push(p)
+
+    if (parties[r].side === party.side) {
+      returns.push(new Matchup(returns.length, party))
+
+      return returns
+    }
+
+    ns.push(r)
+
+    returns.push(new Matchup(returns.length, party, parties[r]))
+
+    return returns
+  }, [])
+}
+
+/**
  * Create and register matches.
  *
- * @param {import('./parties').MatchSided[]} sidedMatches All registered participants for each round
+ * @param {Matchup[]} matchups All registered matchups for each round
  * @param {number} round Index of current round
  * @param {(num: number, match: Match) => number} fnId Callback function to create match id for the entry
  * @param {Match[]} matches
  * @param {number[]} byes List of singular match' index
  * @returns {Match[]} List of all registered matches
  */
-export function createMatches(sidedMatches, round, fnId = num => num, matches = [], byes = []) {
-  const half = Math.floor(sidedMatches.length / 2)
+export function createMatches(matchups, round, fnId = num => num, matches = [], byes = []) {
+  const half = Math.floor(matchups.length / 2)
 
   // Split match entries in half on each round with certain criteria
   const chunks = half >= 2
     ? [
-        sidedMatches.slice(0, half),
-        sidedMatches.slice(half),
+        matchups.slice(0, half),
+        matchups.slice(half),
       ]
     : [
-        sidedMatches,
+        matchups,
         [],
       ]
 
   if (byes.length === 0) {
-    byes = sidedMatches.reduce((byes, side) => {
-      if (side.red === undefined) {
-        byes.push(side.index)
+    byes = matchups.reduce((byes, matchup) => {
+      if (matchup.singular) {
+        byes.push(matchup.index)
       }
 
       return byes
@@ -204,32 +266,31 @@ export function createMatches(sidedMatches, round, fnId = num => num, matches = 
 
   let hasByes = byes.length > 0
 
-  return chunks.reduce((matches, sides) => {
-    if (sides.length === 0) {
+  return chunks.reduce((matches, matchups) => {
+    if (matchups.length === 0) {
       return matches
     }
 
     // Recusively calculate when the number of `sides` on `round` 0 is 5 or more
-    if (round === 0 && sides.length >= 5) {
-      createMatches(sides, round, fnId, matches, byes)
+    if (round === 0 && matchups.length >= 5) {
+      createMatches(matchups, round, fnId, matches, byes)
 
       return matches
     }
 
     // The `hasByes` might be negated by prior iteration so let reassure the value
     if (!hasByes && matches.at(-1)?.bye === false) {
-      hasByes = sides.some(side => side.red === undefined)
+      hasByes = matchups.some(matchup => matchup.singular)
     }
 
-    sides.forEach((side, index, split) => {
-      const prevMatch = matches.at(-1)
-      const match = new Match(round, side.blue, side.red, () => {
-        return hasByes && side.index < byes.at(-1)
+    matchups.forEach((matchup, index, matchups) => {
+      const match = new Match(round, matchup.blue, matchup.red, () => {
+        return hasByes && matchup.index < byes.at(-1)
       })
 
-      match.initialize(matches, index, split.length, fnId)
+      match.initialize(matches, index, matchups.length, fnId)
 
-      if (match.singular || prevMatch?.singular) {
+      if (match.singular || matches.at(-1)?.singular) {
         hasByes = match.bye = false
       }
 

--- a/lib/matches.js
+++ b/lib/matches.js
@@ -144,8 +144,7 @@ export class Match {
       continent = this.parties[0].continent
     }
 
-    return new Party(name, id, continent)
-      .fromMatch(this, index, matches.length)
+    return new Party(name, id, continent).fromMatch(this, index, matches.length)
   }
 }
 
@@ -208,14 +207,14 @@ export function matchmakingParties(parties) {
   return parties.reduce((returns, party, p, parties) => {
     const r = p + 1
 
-    // Skip if current `p` is already added to `ns`
-    // or current `party` was a red one
+    // Skip if current `p` is already added to `ns` or current `party` was a red one
     if (ns.includes(p) || party.side === 'red' || !parties[r]) {
       return returns
     }
 
     ns.push(p)
 
+    // Continue iteration when current' side is equals to next one
     if (parties[r].side === party.side) {
       returns.push(new Matchup(returns.length, party))
 
@@ -243,7 +242,7 @@ export function matchmakingParties(parties) {
 export function createMatches(matchups, round, fnId = num => num, matches = [], byes = []) {
   const half = Math.floor(matchups.length / 2)
 
-  // Split match entries in half on each round with certain criteria
+  // Split matchup entries in half when it meets certain criteria
   const chunks = half >= 2
     ? [
         matchups.slice(0, half),
@@ -271,14 +270,14 @@ export function createMatches(matchups, round, fnId = num => num, matches = [], 
       return matches
     }
 
-    // Recusively calculate when the number of `sides` on `round` 0 is 5 or more
+    // Recusively calculate when the number of `matchups` on `round` 0 is 5 or more
     if (round === 0 && matchups.length >= 5) {
       createMatches(matchups, round, fnId, matches, byes)
 
       return matches
     }
 
-    // The `hasByes` might be negated by prior iteration so let reassure the value
+    // The `hasByes` might've been negated by prior iteration so let reassure the value
     if (!hasByes && matches.at(-1)?.bye === false) {
       hasByes = matchups.some(matchup => matchup.singular)
     }

--- a/lib/matches.js
+++ b/lib/matches.js
@@ -41,9 +41,9 @@ export class Match {
    * @param {number} round
    * @param {import('./parties').Party} blue
    * @param {import('./parties').Party|undefined} red
-   * @param {() => boolean} fnBye
+   * @param {boolean} bye
    */
-  constructor(round, blue, red = undefined, fnBye = () => false) {
+  constructor(round, blue, red = undefined, bye = false) {
     this.round = round
     this.parties = [blue]
 
@@ -52,7 +52,7 @@ export class Match {
     }
 
     if (round === 0) {
-      this.bye = fnBye()
+      this.bye = bye
     }
 
     if (this.singular) {
@@ -188,6 +188,17 @@ export class Matchup {
     this.blue = blue
     this.red = red
   }
+
+  /**
+   * Convert this matchup to a match.
+   *
+   * @param {number} round Round index
+   * @param {boolean} hasByes Whether this iterations has some bye matches
+   * @param {number|undefined} latestBye Latest bye match index
+   */
+  toMatch(round, hasByes, latestBye) {
+    return new Match(round, this.blue, this.red, hasByes && this.index < latestBye)
+  }
 }
 
 /**
@@ -283,9 +294,7 @@ export function createMatches(matchups, round, fnId = num => num, matches = [], 
     }
 
     matchups.forEach((matchup, index, matchups) => {
-      const match = new Match(round, matchup.blue, matchup.red, () => {
-        return hasByes && matchup.index < byes.at(-1)
-      })
+      const match = matchup.toMatch(round, hasByes, byes.at(-1))
 
       match.initialize(matches, index, matchups.length, fnId)
 

--- a/lib/parties.js
+++ b/lib/parties.js
@@ -72,61 +72,6 @@ export class Party {
   }
 }
 
-export class MatchSided {
-  /** @type {number} */
-  index = 0
-
-  /**
-   * @param {number} index
-   * @param {Party} blue
-   * @param {Party|undefined} red
-   */
-  constructor(index, blue, red = undefined) {
-    this.index = index
-    this.blue = blue
-    this.red = red
-  }
-}
-
-/**
- * Rearrange participant based on their match side.
- *
- * @param {Party[]} parties List of available participants
- * @returns {MatchSided[]}
- */
-export function rearrangePartiesBySide(parties) {
-  // Ensure current parties has correct ordering based on their
-  // prior total match compared to their index on that match
-  parties.sort((a, b) => a.order - b.order)
-
-  // Track index of `parties` that has been added to `returns`
-  const ns = []
-
-  return parties.reduce((returns, party, p, parties) => {
-    const r = p + 1
-
-    // Skip if current `p` is already added to `ns`
-    // or current `party` was a red one
-    if (ns.includes(p) || party.side === 'red' || !parties[r]) {
-      return returns
-    }
-
-    ns.push(p)
-
-    if (parties[r].side === party.side) {
-      returns.push(new MatchSided(returns.length, party))
-
-      return returns
-    }
-
-    ns.push(r)
-
-    returns.push(new MatchSided(returns.length, party, parties[r]))
-
-    return returns
-  }, [])
-}
-
 /**
  * Generate participants base on desired number of participant.
  *

--- a/lib/parties.js
+++ b/lib/parties.js
@@ -130,18 +130,13 @@ export function rearrangePartiesBySide(parties) {
 /**
  * Generate participants base on desired number of participant.
  *
- * @param {number} count Number of participant
- * @returns {Party[]}
+ * @param {number} length Number of participants
  */
-export function generateParties(count) {
-  /** @type {Party[]} */
-  const parties = []
-
-  for (let id = 1; id <= count; id++) {
-    parties.push(
-      new Party(`Participant ${id}`, id, `Continent ${id}`),
-    )
-  }
+export function generateParties(length) {
+  const parties = [...Array.from({ length }).keys()].map((i) => {
+    const id = i + 1
+    return new Party(`Participant ${id}`, id, `Continent ${id}`)
+  })
 
   return determinePartiesSide(parties)
 }

--- a/lib/rounds.js
+++ b/lib/rounds.js
@@ -1,5 +1,4 @@
-import { createMatches } from './matches.js'
-import { rearrangePartiesBySide } from './parties.js'
+import { createMatches, matchmakingParties } from './matches.js'
 
 export class Round {
   /** @type {number} Round Index */
@@ -36,9 +35,9 @@ export class Round {
     const parties = this.#prepareParties(rounds)
 
     if (parties.length > 0) {
-      const sidedMatches = rearrangePartiesBySide(parties)
+      const matchups = matchmakingParties(parties)
 
-      this.matches = createMatches(sidedMatches, this.#index, (num, match) => {
+      this.matches = createMatches(matchups, this.#index, (num, match) => {
         if (match.round === this.#index) {
           return num + (prevRound?.lastestMatchId() || 0)
         }


### PR DESCRIPTION
Previously I call it `MatchSided` to indicate the results of arranging an contestant to face their opponent. And recently I figured that was wrong, the term that commonly use to indicate that should be the following :

- `Matchup` : The result of the matchmaking process where two contestants have been arranged to face each other but have not yet been scheduled.
- `matchmaking` : The process of deciding which contestant goes to which `side` in a tournament.

And either terms should belongs to `matches` context instead of `parties`.